### PR TITLE
Update link to interaction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Now follow the [interaction instructions][interaction].
 
 [acceptance-test]:https://github.com/camelpunch/pong_matcher_acceptance
 [pws]:https://run.pivotal.io
-[interaction]:https://github.com/camelpunch/pong_matcher_grails#interaction-instructions
+[interaction]:https://github.com/cloudfoundry-samples/pong_matcher_rails/blob/master/README.md#interaction-instructions


### PR DESCRIPTION
Link to interaction instructions was broken. Pointed to instructions in pong_matcher_rails README.md.