### PR TITLE
Improvements in domain classes

### DIFF
--- a/src/main/java/org/pongmatcher/domain/Match.java
+++ b/src/main/java/org/pongmatcher/domain/Match.java
@@ -10,13 +10,13 @@ import javax.persistence.Table;
 @Table(name = "`match`")
 public final class Match {
     @Id
-    private volatile String id;
+    private String id;
 
     @JsonProperty("match_request_1_id")
-    private volatile String matchRequest1Id;
+    private String matchRequest1Id;
 
     @JsonProperty("match_request_2_id")
-    private volatile String matchRequest2Id;
+    private String matchRequest2Id;
 
     Match() {
     }

--- a/src/main/java/org/pongmatcher/domain/MatchRequest.java
+++ b/src/main/java/org/pongmatcher/domain/MatchRequest.java
@@ -9,11 +9,11 @@ public final class MatchRequest {
 
     @GeneratedValue
     @Id
-    private volatile Long id;
+    private Long id;
 
-    private volatile String uuid;
+    private String uuid;
 
-    private volatile String requesterId;
+    private String requesterId;
 
     MatchRequest() {
     }

--- a/src/main/java/org/pongmatcher/domain/Result.java
+++ b/src/main/java/org/pongmatcher/domain/Result.java
@@ -10,36 +10,37 @@ import java.util.UUID;
 public final class Result {
 
     @Id
-    private volatile String id = UUID.randomUUID().toString();
+    private  String id = UUID.randomUUID().toString();
 
-    private volatile String winnerId;
+    @JsonProperty("winner")
+    private  String winnerId;
 
-    private volatile String loserId;
+    @JsonProperty("loser")
+    private  String loserId;
 
-    private volatile String matchId;
+    @JsonProperty("match_id")
+    private  String matchId;
 
     Result() {
     }
 
-    public Result(@JsonProperty("winner") String winnerId,
-                  @JsonProperty("loser") String loserId,
-                  @JsonProperty("match_id") String matchId) {
+    public Result(String winnerId,
+                  String loserId,
+                  String matchId) {
         this.winnerId = winnerId;
         this.loserId = loserId;
         this.matchId = matchId;
     }
 
-    @JsonProperty("winner")
+
     public String getWinnerId() {
         return winnerId;
     }
 
-    @JsonProperty("loser")
     public String getLoserId() {
         return loserId;
     }
 
-    @JsonProperty("match_id")
     public String getMatchId() {
         return matchId;
     }


### PR DESCRIPTION
### Why
`volatile` modifiers are not required in the domain classes' fields, as they're created by Spring Data and not shared in a multithreaded environment.

`JsonProperty` annotations can be associated to the field declaration when we want to use the name for that property in the input and output JSONs. This way we have removed duplication of the annotation.

### What
- Removed unnecessary volatile modifiers in domain classes
- Moved JsonProperty annotations to class fields to avoid duplication in constructor + getter